### PR TITLE
Update gatsby-plugin-mdx version due to dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gatsby-plugin-google-tagmanager": "^2.11.0",
     "gatsby-plugin-layout": "^1.10.0",
     "gatsby-plugin-manifest": "^2.12.1",
-    "gatsby-plugin-mdx": "^1.10.1",
+    "gatsby-plugin-mdx": "^2.14.1",
     "gatsby-plugin-offline": "^3.10.2",
     "gatsby-plugin-preconnect": "^1.2.0",
     "gatsby-plugin-react-helmet": "^3.10.0",


### PR DESCRIPTION
Update gatsby-plugin-mdx version due to dependabot alerts
 - confirmed the build and deply work ok.
 - If updating all dependent package versions, the build doesn't work  